### PR TITLE
Update diagnostic.lua

### DIFF
--- a/lua/joe-p/diagnostic.lua
+++ b/lua/joe-p/diagnostic.lua
@@ -99,13 +99,13 @@ vim.diagnostic.config {
 
 local last_line = vim.fn.line '.'
 
-vim.api.nvim_create_autocmd({ 'CursorMoved' }, {
+vim.api.nvim_create_autocmd({ 'CursorHold' }, {
   callback = function()
     local current_line = vim.fn.line '.'
 
     -- Check if the cursor has moved to a different line
     if current_line ~= last_line then
-      vim.diagnostic.hide()
+      --vim.diagnostic.hide()
       vim.diagnostic.show()
     end
 


### PR DESCRIPTION
Refreshing on CursorMoved events is taxing on low-end systems (I.e. Chromebook) and produces overbearing lag while navigating.

CursorHold doesn't have this effect and doesn't noticeably impact the overall word-wrap feature for virtual_lines.

## Summary by Sourcery

Use CursorHold instead of CursorMoved for updating diagnostics to reduce lag on low-end systems

Enhancements:
- Replace CursorMoved autocmd with CursorHold for triggering diagnostic updates
- Remove redundant diagnostic.hide call before showing diagnostics