### PR TITLE
Updated diagnostics.lua

### DIFF
--- a/lua/joe-p/diagnostic.lua
+++ b/lua/joe-p/diagnostic.lua
@@ -2,30 +2,30 @@ if vim.g.vscode then
   return
 end
 
--- latest version of diagnostic symbols
+-- Latest version of diagnostic symbols (updated on CursorHold)
 local current_signs
 
 -- Get the window id for a buffer
 -- @param bufnr integer
 local function buf_to_win(bufnr)
-	local current_win = vim.fn.win_getid()
+  local current_win = vim.fn.win_getid()
 
-	-- Check if current window has the buffer
-	if vim.fn.winbufnr(current_win) == bufnr then
-		return current_win
-	end
+  -- Check if current window has the buffer
+  if vim.fn.winbufnr(current_win) == bufnr then
+    return current_win
+  end
 
-	-- Otherwise, find a visible window with this buffer
-	local win_ids = vim.fn.win_findbuf(bufnr)
-	local current_tabpage = vim.fn.tabpagenr()
+  -- Otherwise, find a visible window with this buffer
+  local win_ids = vim.fn.win_findbuf(bufnr)
+  local current_tabpage = vim.fn.tabpagenr()
 
-	for _, win_id in ipairs(win_ids) do
-		if vim.fn.win_id2tabwin(win_id)[1] == current_tabpage then
-			return win_id
-		end
-	end
+  for _, win_id in ipairs(win_ids) do
+    if vim.fn.win_id2tabwin(win_id)[1] == current_tabpage then
+      return win_id
+    end
+  end
 
-	return current_win
+  return current_win
 end
 
 -- Split a string into multiple lines, each no longer than max_width
@@ -33,99 +33,98 @@ end
 -- @param str string
 -- @param max_width integer
 local function split_line(str, max_width)
-	if #str <= max_width then
-		return { str }
-	end
+  if #str <= max_width then
+    return { str }
+  end
 
-	local lines = {}
-	local current_line = ""
+  local lines = {}
+  local current_line = ""
 
-	for word in string.gmatch(str, "%S+") do
-		-- If adding this word would exceed max_width
-		if #current_line + #word + 1 > max_width then
-			-- Add the current line to our results
-			table.insert(lines, current_line)
-			current_line = word
-		else
-			-- Add word to the current line with a space if needed
-			if current_line ~= "" then
-				current_line = current_line .. " " .. word
-			else
-				current_line = word
-			end
-		end
-	end
+  for word in string.gmatch(str, "%S+") do
+    -- If adding this word would exceed max_width
+    if #current_line + #word + 1 > max_width then
+      -- Add the current line to our results
+      table.insert(lines, current_line)
+      current_line = word
+    else
+      -- Add word to the current line with a space if needed
+      if current_line ~= "" then
+        current_line = current_line .. " " .. word
+      else
+        current_line = word
+      end
+    end
+  end
 
-	-- Don't forget the last line
-	if current_line ~= "" then
-		table.insert(lines, current_line)
-	end
+  -- Don't forget the last line
+  if current_line ~= "" then
+    table.insert(lines, current_line)
+  end
 
-	return lines
+  return lines
 end
 
 ---@param diagnostic vim.Diagnostic
 local function virtual_lines_format(diagnostic)
-	local win = buf_to_win(diagnostic.bufnr)
-	local sign_column_width = vim.fn.getwininfo(win)[1].textoff
-	local text_area_width = vim.api.nvim_win_get_width(win) - sign_column_width
-	local center_width = 5
-	local left_width = 1
+  local win = buf_to_win(diagnostic.bufnr)
+  local sign_column_width = vim.fn.getwininfo(win)[1].textoff
+  local text_area_width = vim.api.nvim_win_get_width(win) - sign_column_width
+  local center_width = 5
+  local left_width = 1
 
-	---@type string[]
-	local lines = {}
-	for msg_line in diagnostic.message:gmatch("([^\n]+)") do
-		local max_width = text_area_width - diagnostic.col - center_width - left_width
-		local symbol = current_signs.text[diagnostic.severity]
-		vim.list_extend(lines, split_line(symbol .. " " .. msg_line, max_width))
-	end
+  ---@type string[]
+  local lines = {}
+  for msg_line in diagnostic.message:gmatch("([^\n]+)") do
+    local max_width = text_area_width - diagnostic.col - center_width - left_width
+    local symbol = current_signs.text[diagnostic.severity]
+    vim.list_extend(lines, split_line(symbol .. " " .. msg_line, max_width))
+  end
 
-	return table.concat(lines, "\n")
+  return table.concat(lines, "\n")
 end
 
 -- Don't show virtual text on current line since we'll show virtual_lines
 ---@param diagnostic vim.Diagnostic
 local function virtual_text_format(diagnostic)
-	if vim.fn.line(".") == diagnostic.lnum + 1 then
-		return nil
-	end
-  
-	return diagnostic.message
+  if vim.fn.line(".") == diagnostic.lnum + 1 then
+    return nil
+  end
+  return diagnostic.message
 end
 
 vim.diagnostic.config({
-	virtual_text = { format = virtual_text_format },
-	virtual_lines = { format = virtual_lines_format, current_line = true },
-	severity_sort = { reverse = false },
+  virtual_text = { format = virtual_text_format },
+  virtual_lines = { format = virtual_lines_format, current_line = true },
+  severity_sort = { reverse = false },
 })
 
 local function update_signs()
-	current_signs = vim.diagnostic.config().signs or {}
-	local function confirm_sign(expected_key, value_to_set)
-		if current_signs.text[expected_key] == nil then
-			current_signs.text[expected_key] = "(" .. value_to_set .. ")"
-		end
-	end
-	confirm_sign(vim.diagnostic.severity.HINT, "H")
-	confirm_sign(vim.diagnostic.severity.INFO, "I")
-	confirm_sign(vim.diagnostic.severity.WARN, "W")
-	confirm_sign(vim.diagnostic.severity.ERROR, "E")
+  current_signs = vim.diagnostic.config().signs or {}
+  local function confirm_sign(expected_key, value_to_set)
+    if current_signs.text[expected_key] == nil then
+      current_signs.text[expected_key] = "(" .. value_to_set .. ")"
+    end
+  end
+  confirm_sign(vim.diagnostic.severity.HINT, "H")
+  confirm_sign(vim.diagnostic.severity.INFO, "I")
+  confirm_sign(vim.diagnostic.severity.WARN, "W")
+  confirm_sign(vim.diagnostic.severity.ERROR, "E")
 end
 
 -- Re-draw diagnostics once navigation has ended
 
 vim.api.nvim_create_autocmd({ "CursorHold" }, {
-	callback = function()
-		update_signs()
-		vim.diagnostic.show()
-	end,
+  callback = function()
+    update_signs()
+    vim.diagnostic.show()
+  end,
 })
 
 -- Re-render diagnostics when the window is resized
 
 vim.api.nvim_create_autocmd("VimResized", {
-	callback = function()
-		vim.diagnostic.hide()
-		vim.diagnostic.show()
-	end,
+  callback = function()
+    vim.diagnostic.hide()
+    vim.diagnostic.show()
+  end,
 })

--- a/lua/joe-p/diagnostic.lua
+++ b/lua/joe-p/diagnostic.lua
@@ -99,13 +99,13 @@ vim.diagnostic.config {
 
 local last_line = vim.fn.line '.'
 
-vim.api.nvim_create_autocmd({ 'CursorMoved' }, {
+vim.api.nvim_create_autocmd({ 'CursorHold' }, {
   callback = function()
     local current_line = vim.fn.line '.'
 
     -- Check if the cursor has moved to a different line
     if current_line ~= last_line then
-      vim.diagnostic.hide()
+      --vim.diagnostic.hide()
       vim.diagnostic.show()
     end
 

--- a/lua/joe-p/diagnostic.lua
+++ b/lua/joe-p/diagnostic.lua
@@ -2,30 +2,30 @@ if vim.g.vscode then
   return
 end
 
--- Latest version of diagnostic symbols (updated on CursorHold)
+-- latest version of diagnostic symbols
 local current_signs
 
 -- Get the window id for a buffer
 -- @param bufnr integer
 local function buf_to_win(bufnr)
-  local current_win = vim.fn.win_getid()
+	local current_win = vim.fn.win_getid()
 
-  -- Check if current window has the buffer
-  if vim.fn.winbufnr(current_win) == bufnr then
-    return current_win
-  end
+	-- Check if current window has the buffer
+	if vim.fn.winbufnr(current_win) == bufnr then
+		return current_win
+	end
 
-  -- Otherwise, find a visible window with this buffer
-  local win_ids = vim.fn.win_findbuf(bufnr)
-  local current_tabpage = vim.fn.tabpagenr()
+	-- Otherwise, find a visible window with this buffer
+	local win_ids = vim.fn.win_findbuf(bufnr)
+	local current_tabpage = vim.fn.tabpagenr()
 
-  for _, win_id in ipairs(win_ids) do
-    if vim.fn.win_id2tabwin(win_id)[1] == current_tabpage then
-      return win_id
-    end
-  end
+	for _, win_id in ipairs(win_ids) do
+		if vim.fn.win_id2tabwin(win_id)[1] == current_tabpage then
+			return win_id
+		end
+	end
 
-  return current_win
+	return current_win
 end
 
 -- Split a string into multiple lines, each no longer than max_width
@@ -33,86 +33,99 @@ end
 -- @param str string
 -- @param max_width integer
 local function split_line(str, max_width)
-  if #str <= max_width then
-    return { str }
-  end
+	if #str <= max_width then
+		return { str }
+	end
 
-  local lines = {}
-  local current_line = ''
+	local lines = {}
+	local current_line = ""
 
-  for word in string.gmatch(str, '%S+') do
-    -- If adding this word would exceed max_width
-    if #current_line + #word + 1 > max_width then
-      -- Add the current line to our results
-      table.insert(lines, current_line)
-      current_line = word
-    else
-      -- Add word to the current line with a space if needed
-      if current_line ~= '' then
-        current_line = current_line .. ' ' .. word
-      else
-        current_line = word
-      end
-    end
-  end
+	for word in string.gmatch(str, "%S+") do
+		-- If adding this word would exceed max_width
+		if #current_line + #word + 1 > max_width then
+			-- Add the current line to our results
+			table.insert(lines, current_line)
+			current_line = word
+		else
+			-- Add word to the current line with a space if needed
+			if current_line ~= "" then
+				current_line = current_line .. " " .. word
+			else
+				current_line = word
+			end
+		end
+	end
 
-  -- Don't forget the last line
-  if current_line ~= '' then
-    table.insert(lines, current_line)
-  end
+	-- Don't forget the last line
+	if current_line ~= "" then
+		table.insert(lines, current_line)
+	end
 
-  return lines
+	return lines
 end
 
 ---@param diagnostic vim.Diagnostic
 local function virtual_lines_format(diagnostic)
-  local win = buf_to_win(diagnostic.bufnr)
-  local sign_column_width = vim.fn.getwininfo(win)[1].textoff
-  local text_area_width = vim.api.nvim_win_get_width(win) - sign_column_width
-  local center_width = 5
-  local left_width = 1
+	local win = buf_to_win(diagnostic.bufnr)
+	local sign_column_width = vim.fn.getwininfo(win)[1].textoff
+	local text_area_width = vim.api.nvim_win_get_width(win) - sign_column_width
+	local center_width = 5
+	local left_width = 1
 
-  ---@type string[]
-  local lines = {}
-  for msg_line in diagnostic.message:gmatch '([^\n]+)' do
-    local max_width = text_area_width - diagnostic.col - center_width - left_width
-    local symbol = current_signs.text[diagnostic.severity]
-    vim.list_extend(lines, split_line(symbol .. " " .. msg_line, max_width))
-  end
+	---@type string[]
+	local lines = {}
+	for msg_line in diagnostic.message:gmatch("([^\n]+)") do
+		local max_width = text_area_width - diagnostic.col - center_width - left_width
+		local symbol = current_signs.text[diagnostic.severity]
+		vim.list_extend(lines, split_line(symbol .. " " .. msg_line, max_width))
+	end
 
-  return table.concat(lines, '\n')
+	return table.concat(lines, "\n")
 end
 
 -- Don't show virtual text on current line since we'll show virtual_lines
 ---@param diagnostic vim.Diagnostic
 local function virtual_text_format(diagnostic)
-  if vim.fn.line '.' == diagnostic.lnum + 1 then
-    return nil
-  end
-
-  return diagnostic.message
+	if vim.fn.line(".") == diagnostic.lnum + 1 then
+		return nil
+	end
+  
+	return diagnostic.message
 end
 
-vim.diagnostic.config {
-  virtual_text = { format = virtual_text_format, severity = { min = vim.diagnostic.severity.WARN } },
-  virtual_lines = { format = virtual_lines_format, current_line = true },
-  severity_sort = { reverse = false },
-}
+vim.diagnostic.config({
+	virtual_text = { format = virtual_text_format },
+	virtual_lines = { format = virtual_lines_format, current_line = true },
+	severity_sort = { reverse = false },
+})
+
+local function update_signs()
+	current_signs = vim.diagnostic.config().signs or {}
+	local function confirm_sign(expected_key, value_to_set)
+		if current_signs.text[expected_key] == nil then
+			current_signs.text[expected_key] = "(" .. value_to_set .. ")"
+		end
+	end
+	confirm_sign(vim.diagnostic.severity.HINT, "H")
+	confirm_sign(vim.diagnostic.severity.INFO, "I")
+	confirm_sign(vim.diagnostic.severity.WARN, "W")
+	confirm_sign(vim.diagnostic.severity.ERROR, "E")
+end
 
 -- Re-draw diagnostics once navigation has ended
 
-vim.api.nvim_create_autocmd({ 'CursorHold' }, {
-  callback = function()
-      current_signs = vim.diagnostic.config().signs
-    vim.diagnostic.show()
-  end,
+vim.api.nvim_create_autocmd({ "CursorHold" }, {
+	callback = function()
+		update_signs()
+		vim.diagnostic.show()
+	end,
 })
 
 -- Re-render diagnostics when the window is resized
 
-vim.api.nvim_create_autocmd('VimResized', {
-  callback = function()
-    vim.diagnostic.hide()
-    vim.diagnostic.show()
-  end,
+vim.api.nvim_create_autocmd("VimResized", {
+	callback = function()
+		vim.diagnostic.hide()
+		vim.diagnostic.show()
+	end,
 })

--- a/lua/joe-p/diagnostic.lua
+++ b/lua/joe-p/diagnostic.lua
@@ -95,22 +95,11 @@ vim.diagnostic.config {
   severity_sort = { reverse = false },
 }
 
--- Re-draw diagnostics each line change to account for virtual_text changes
-
-local last_line = vim.fn.line '.'
+-- Re-draw diagnostics once navigation has ended
 
 vim.api.nvim_create_autocmd({ 'CursorHold' }, {
   callback = function()
-    local current_line = vim.fn.line '.'
-
-    -- Check if the cursor has moved to a different line
-    if current_line ~= last_line then
-      --vim.diagnostic.hide()
-      vim.diagnostic.show()
-    end
-
-    -- Update the last_line variable
-    last_line = current_line
+    vim.diagnostic.show()
   end,
 })
 

--- a/lua/joe-p/diagnostic.lua
+++ b/lua/joe-p/diagnostic.lua
@@ -2,30 +2,51 @@ if vim.g.vscode then
   return
 end
 
+-- Uses CursorModed when true, else CursorHold.
+-- CursorHold introduces minor delay in updating virtual_text (i.e. hidden/visible)
+local opt_high_performance_mode = false
+-- Add severity symbols to start of virtual_line output.
+local opt_add_symbols = true
+
 -- Latest version of diagnostic symbols (updated on CursorHold)
 local current_signs
+
+local function update_signs()
+	current_signs = vim.diagnostic.config().signs or {}
+	local function confirm_sign(expected_key, value_to_set)
+		if current_signs.text[expected_key] == nil then
+			current_signs.text[expected_key] = "(" .. value_to_set .. ")"
+		end
+	end
+	confirm_sign(vim.diagnostic.severity.HINT, "H")
+	confirm_sign(vim.diagnostic.severity.INFO, "I")
+	confirm_sign(vim.diagnostic.severity.WARN, "W")
+	confirm_sign(vim.diagnostic.severity.ERROR, "E")
+end
+
+update_signs() -- init values
 
 -- Get the window id for a buffer
 -- @param bufnr integer
 local function buf_to_win(bufnr)
-  local current_win = vim.fn.win_getid()
+	local current_win = vim.fn.win_getid()
 
-  -- Check if current window has the buffer
-  if vim.fn.winbufnr(current_win) == bufnr then
-    return current_win
-  end
+	-- Check if current window has the buffer
+	if vim.fn.winbufnr(current_win) == bufnr then
+		return current_win
+	end
 
-  -- Otherwise, find a visible window with this buffer
-  local win_ids = vim.fn.win_findbuf(bufnr)
-  local current_tabpage = vim.fn.tabpagenr()
+	-- Otherwise, find a visible window with this buffer
+	local win_ids = vim.fn.win_findbuf(bufnr)
+	local current_tabpage = vim.fn.tabpagenr()
 
-  for _, win_id in ipairs(win_ids) do
-    if vim.fn.win_id2tabwin(win_id)[1] == current_tabpage then
-      return win_id
-    end
-  end
+	for _, win_id in ipairs(win_ids) do
+		if vim.fn.win_id2tabwin(win_id)[1] == current_tabpage then
+			return win_id
+		end
+	end
 
-  return current_win
+	return current_win
 end
 
 -- Split a string into multiple lines, each no longer than max_width
@@ -33,98 +54,109 @@ end
 -- @param str string
 -- @param max_width integer
 local function split_line(str, max_width)
-  if #str <= max_width then
-    return { str }
-  end
+	if #str <= max_width then
+		return { str }
+	end
 
-  local lines = {}
-  local current_line = ""
+	local lines = {}
+	local current_line = ""
 
-  for word in string.gmatch(str, "%S+") do
-    -- If adding this word would exceed max_width
-    if #current_line + #word + 1 > max_width then
-      -- Add the current line to our results
-      table.insert(lines, current_line)
-      current_line = word
-    else
-      -- Add word to the current line with a space if needed
-      if current_line ~= "" then
-        current_line = current_line .. " " .. word
-      else
-        current_line = word
-      end
-    end
-  end
+	for word in string.gmatch(str, "%S+") do
+		-- If adding this word would exceed max_width
+		if #current_line + #word + 1 > max_width then
+			-- Add the current line to our results
+			table.insert(lines, current_line)
+			current_line = word
+		else
+			-- Add word to the current line with a space if needed
+			if current_line ~= "" then
+				current_line = current_line .. " " .. word
+			else
+				current_line = word
+			end
+		end
+	end
 
-  -- Don't forget the last line
-  if current_line ~= "" then
-    table.insert(lines, current_line)
-  end
+	-- Don't forget the last line
+	if current_line ~= "" then
+		table.insert(lines, current_line)
+	end
 
-  return lines
+	return lines
 end
 
 ---@param diagnostic vim.Diagnostic
 local function virtual_lines_format(diagnostic)
-  local win = buf_to_win(diagnostic.bufnr)
-  local sign_column_width = vim.fn.getwininfo(win)[1].textoff
-  local text_area_width = vim.api.nvim_win_get_width(win) - sign_column_width
-  local center_width = 5
-  local left_width = 1
+	local win = buf_to_win(diagnostic.bufnr)
+	local sign_column_width = vim.fn.getwininfo(win)[1].textoff
+	local text_area_width = vim.api.nvim_win_get_width(win) - sign_column_width
+	local center_width = 5
+	local left_width = 1
 
-  ---@type string[]
-  local lines = {}
-  for msg_line in diagnostic.message:gmatch("([^\n]+)") do
-    local max_width = text_area_width - diagnostic.col - center_width - left_width
-    local symbol = current_signs.text[diagnostic.severity]
-    vim.list_extend(lines, split_line(symbol .. " " .. msg_line, max_width))
-  end
+	---@type string[]
+	local lines = {}
+	for msg_line in diagnostic.message:gmatch("([^\n]+)") do
+		local max_width = text_area_width - diagnostic.col - center_width - left_width
+		local prefix = ""
+		if opt_add_symbols then
+			local symbol = current_signs.text[diagnostic.severity]
+			if symbol ~= nil then
+				prefix = symbol .. " "
+			end
+		end
 
-  return table.concat(lines, "\n")
+		vim.list_extend(lines, split_line(prefix .. msg_line, max_width))
+	end
+
+	return table.concat(lines, "\n")
 end
 
 -- Don't show virtual text on current line since we'll show virtual_lines
 ---@param diagnostic vim.Diagnostic
 local function virtual_text_format(diagnostic)
-  if vim.fn.line(".") == diagnostic.lnum + 1 then
-    return nil
-  end
-  return diagnostic.message
+	if vim.fn.line(".") == diagnostic.lnum + 1 then
+		return nil
+	end
+	return diagnostic.message
 end
 
 vim.diagnostic.config({
-  virtual_text = { format = virtual_text_format },
-  virtual_lines = { format = virtual_lines_format, current_line = true },
-  severity_sort = { reverse = false },
+	virtual_text = { format = virtual_text_format },
+	virtual_lines = { format = virtual_lines_format, current_line = true },
+	severity_sort = { reverse = false },
 })
 
-local function update_signs()
-  current_signs = vim.diagnostic.config().signs or {}
-  local function confirm_sign(expected_key, value_to_set)
-    if current_signs.text[expected_key] == nil then
-      current_signs.text[expected_key] = "(" .. value_to_set .. ")"
-    end
-  end
-  confirm_sign(vim.diagnostic.severity.HINT, "H")
-  confirm_sign(vim.diagnostic.severity.INFO, "I")
-  confirm_sign(vim.diagnostic.severity.WARN, "W")
-  confirm_sign(vim.diagnostic.severity.ERROR, "E")
+-- Update signs in case they have changed
+vim.api.nvim_create_autocmd("CursorHold", {
+	callback = update_signs,
+})
+
+-- Re-draw diagnostics once navigation has ended, or on navigation if in
+-- high performance mode
+
+local last_line = -1
+
+local auto_events = "CursorHold"
+if opt_high_performance_mode then
+	auto_events = "CursorMoved"
 end
 
--- Re-draw diagnostics once navigation has ended
+vim.api.nvim_create_autocmd(auto_events, {
+	callback = function()
+		local current_line = vim.fn.line(".")
 
-vim.api.nvim_create_autocmd({ "CursorHold" }, {
-  callback = function()
-    update_signs()
-    vim.diagnostic.show()
-  end,
+		if current_line ~= last_line then
+			vim.diagnostic.show()
+			last_line = current_line
+		end
+	end,
 })
 
 -- Re-render diagnostics when the window is resized
 
 vim.api.nvim_create_autocmd("VimResized", {
-  callback = function()
-    vim.diagnostic.hide()
-    vim.diagnostic.show()
-  end,
+	callback = function()
+		vim.diagnostic.hide()
+		vim.diagnostic.show()
+	end,
 })

--- a/lua/joe-p/diagnostic.lua
+++ b/lua/joe-p/diagnostic.lua
@@ -2,6 +2,9 @@ if vim.g.vscode then
   return
 end
 
+-- Latest version of diagnostic symbols (updated on CursorHold)
+local current_signs
+
 -- Get the window id for a buffer
 -- @param bufnr integer
 local function buf_to_win(bufnr)
@@ -73,7 +76,8 @@ local function virtual_lines_format(diagnostic)
   local lines = {}
   for msg_line in diagnostic.message:gmatch '([^\n]+)' do
     local max_width = text_area_width - diagnostic.col - center_width - left_width
-    vim.list_extend(lines, split_line(msg_line, max_width))
+    local symbol = current_signs.text[diagnostic.severity]
+    vim.list_extend(lines, split_line(symbol .. " " .. msg_line, max_width))
   end
 
   return table.concat(lines, '\n')
@@ -99,6 +103,7 @@ vim.diagnostic.config {
 
 vim.api.nvim_create_autocmd({ 'CursorHold' }, {
   callback = function()
+      current_signs = vim.diagnostic.config().signs
     vim.diagnostic.show()
   end,
 })


### PR DESCRIPTION
- Updating the virtual lines/text on CursorMoved is taxing and noticeable on low-end hardware (I.e. Chromebook).  Changing the event to CursorHold has no performance impact, with the cost of a possible slight delay after ending navigation before the event fires to update the text (add line-wrapping).
- Added severity symbols to the start of virtual_lines.

## Summary by Sourcery

Switch diagnostic updates to CursorHold by default to improve performance on low-end hardware and introduce an optional high-performance mode using CursorMoved, and add configurable severity symbols to virtual diagnostic lines.

Enhancements:
- Switch update trigger from CursorMoved to CursorHold by default with a new high-performance mode option to use CursorMoved
- Add severity symbol prefixing to virtual_lines output and automatically refresh diagnostic signs
- Refine diagnostic redraw logic to only refresh on line changes and window resize